### PR TITLE
Fixed: CP/M hangs after writing to sd image file.

### DIFF
--- a/build_id.v
+++ b/build_id.v
@@ -1,1 +1,1 @@
-`define BUILD_DATE "201227"
+`define BUILD_DATE "210228"

--- a/sys/sd_card.sv
+++ b/sys/sd_card.sv
@@ -59,7 +59,7 @@ assign sd_lba = sdhc ? lba : {9'd0, lba[31:9]};
 
 wire[31:0] OCR = { 1'b1, sdhc, 30'd0 };  // bit30 = 1 -> high capaciry card (sdhc) // bit31 = 0 -> card power up finished
 wire [7:0] READ_DATA_TOKEN     = 8'hfe;
-wire [7:0] WRITE_DATA_RESPONSE = 8'h05;
+wire [7:0] WRITE_DATA_RESPONSE = 8'he5;
 
 // number of bytes to wait after a command before sending the reply
 localparam NCR=3;


### PR DESCRIPTION
The response code from module sd_card sent at the end of executing
CMD24 (state WR_STATE_SEND_DRESP), was not a byte starting with bits 1110
as expected by the sd_controller module. This caused the sd_controller
to assume the result byte is finished and switch off the clock signal prematurely.
After that the system could not recover and return to a working state.
